### PR TITLE
CI/CD pipeline for public gems using GH actions

### DIFF
--- a/.github/workflows/build_release_action.yaml
+++ b/.github/workflows/build_release_action.yaml
@@ -36,13 +36,15 @@ jobs:
           GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_AUTH_TOKEN }}"
 
       - name: Tag repo with new gem version
-        # if: success() && github.ref == 'refs/heads/master'
+        if: success() && github.ref == 'refs/heads/master'
         uses: actions/github-script@v3
         with:
           github-token: ${{ github.token }}
-          env:
-            GEM_VERSION: ${{ v$(bundle exec rake version) }}
           script: |
-            const { GEM_VERSION } = process.env
-            console.log(GEM_VERSION)
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.build.outputs.gem_version }}",
+              sha: context.sha
+            })
             

--- a/.github/workflows/build_release_action.yaml
+++ b/.github/workflows/build_release_action.yaml
@@ -1,0 +1,49 @@
+name: Build and release ruby gem
+
+on:
+  pull_request: 
+    branches: [ master ]
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-release-pipeline:
+    runs-on: ubuntu-latest
+    container: ruby:2.6.3
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          gem install bundler:1.17.3
+          bundle install
+
+      - name: Build
+        id: build
+        if: success() && github.ref == 'refs/heads/master'
+        run: |
+          bundle exec rake build
+          echo "::set-output name=gem_version::$(cat ./lib/request_local_cache/version.rb | grep VERSION | sed "s/'//g" | sed 's/"//g' | awk '{ print "v"$3 }')"
+
+      - name: Release
+        if: success() && github.ref == 'refs/heads/master'
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem push pkg/*
+        env:
+          GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_AUTH_TOKEN }}"
+
+      - name: Tag repo with new gem version
+        if: success() && github.ref == 'refs/heads/master'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.build.outputs.gem_version }}",
+              sha: context.sha
+            })

--- a/.github/workflows/build_release_action.yaml
+++ b/.github/workflows/build_release_action.yaml
@@ -22,7 +22,7 @@ jobs:
         if: success() && github.ref == 'refs/heads/master'
         run: |
           bundle exec rake build
-          echo "::set-output name=gem_version::$(cat ./lib/request_local_cache/version.rb | grep VERSION | sed "s/'//g" | sed 's/"//g' | awk '{ print "v"$3 }')"
+          echo "::set-output name=gem_version::v$(bundle exec rake version)"
 
       - name: Release
         if: success() && github.ref == 'refs/heads/master'
@@ -36,14 +36,13 @@ jobs:
           GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_AUTH_TOKEN }}"
 
       - name: Tag repo with new gem version
-        if: success() && github.ref == 'refs/heads/master'
+        # if: success() && github.ref == 'refs/heads/master'
         uses: actions/github-script@v3
         with:
           github-token: ${{ github.token }}
+          env:
+            GEM_VERSION: ${{ v$(bundle exec rake version) }}
           script: |
-            github.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/${{ steps.build.outputs.gem_version }}",
-              sha: context.sha
-            })
+            const { GEM_VERSION } = process.env
+            console.log(GEM_VERSION)
+            

--- a/.github/workflows/build_release_action.yaml
+++ b/.github/workflows/build_release_action.yaml
@@ -9,12 +9,12 @@ on:
 jobs:
   build-release-pipeline:
     runs-on: ubuntu-latest
-    container: ruby:2.6.3
+    container: ruby:2.7.2
     steps:
       - uses: actions/checkout@v2
       - name: Setup
         run: |
-          gem install bundler:1.17.3
+          gem install bundler
           bundle install
 
       - name: Build

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,5 @@
 require 'bundler/gem_tasks'
+
+task :version do |t|
+  puts RequestLocalCache::VERSION
+end

--- a/lib/request_local_cache/version.rb
+++ b/lib/request_local_cache/version.rb
@@ -1,3 +1,3 @@
 module RequestLocalCache
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/request_local_cache.gemspec
+++ b/request_local_cache.gemspec
@@ -6,7 +6,7 @@ require 'request_local_cache/version'
 Gem::Specification.new do |spec|
   spec.name          = 'request_local_cache'
   spec.version       = RequestLocalCache::VERSION
-  spec.authors       = ['Karolis Astrauka']
+  spec.authors       = ['Vinted']
   spec.email         = ['admin@vinted.com']
 
   spec.summary       = %q{RequestLocalCache gives you per-request cache}

--- a/request_local_cache.gemspec
+++ b/request_local_cache.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 4.2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
- This gem has no tests, thus one step in the pipeline is missing.
- `workflow_dispatch` allows triggering actions manually from the `Actions` tab in repo.
- `echo "::set-output name=version::$(bundle exec rake version)"` sets newly created gem version as output variable from build step for tagging repository.
